### PR TITLE
chore: update repository links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing to KooL Hyprland Projects! We welcom
 ## Getting Started
 
 1. Fork the branch development repository to your GitHub account. This will create a copy of this repository in your account. You can make changes to this copy without affecting the original repository.
-  - For fork this repository, click the **Fork** button in the top right corner of this page or click [here](https://github.com/JaKooLit/Hyprland-Dots/fork).
+  - For fork this repository, click the **Fork** button in the top right corner of this page or click [here](https://github.com/svglan/arch-dots/fork).
   - Make sure to uncheck the Copy the `main` branch only. This will copy the development branch and other branches (if any)
  
 2. Clone your forked repository to your local machine.
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to KooL Hyprland Projects! We welcom
   - Use the following command to clone your forked repository to your local machine.
 
      ```bash
-     git clone --depth=1 -b development https://github.com/JaKooLit/Hyprland-Dots.git
+     git clone --depth=1 -b development https://github.com/svglan/arch-dots.git
      ```
 
 3. Create a new branch for your changes.
@@ -26,7 +26,7 @@ Thank you for your interest in contributing to KooL Hyprland Projects! We welcom
 
 4. Make your changes and commit them with a descriptive commit message.
 
-  - For example, to commit your changes, use the following command and make sure to follow the [commit message guidelines](https://github.com/JaKooLit/Hyprland-Dots/blob/main/COMMIT_MESSAGE_GUIDELINES.md).
+  - For example, to commit your changes, use the following command and make sure to follow the [commit message guidelines](https://github.com/svglan/arch-dots/blob/main/COMMIT_MESSAGE_GUIDELINES.md).
 
      ```bash
      git commit -m "feat: add a new feature"
@@ -45,7 +45,7 @@ Thank you for your interest in contributing to KooL Hyprland Projects! We welcom
      1. Go to your forked repository.
      2. Click the **Compare & pull request** button next to your `your-branch-name` branch.
      3. Add a title and description for your pull request.
-     4. Click **Create pull request** and remember to add the relevant labels with using the [pull request template](https://github.com/JaKooLit/Hyprland-Dots/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
+     4. Click **Create pull request** and remember to add the relevant labels with using the [pull request template](https://github.com/svglan/arch-dots/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
 
 ## Guidelines
 
@@ -55,15 +55,15 @@ Thank you for your interest in contributing to KooL Hyprland Projects! We welcom
 - Make sure all tests pass or fully tested before submitting your changes.
 - Keep your pull request focused and avoid including unrelated changes.
 - Remember to follow the following files before submitting your changes.
-  - [bug.yml](https://github.com/JaKooLit/Hyprland-Dots/blob/main/.github/ISSUE_TEMPLATE/bug.yml) - Use this template to create a report to help us improve.
-  - [feature.yml](https://github.com/JaKooLit/Hyprland-Dots/blob/main/.github/ISSUE_TEMPLATE/feature.yml) - Use this template to suggest a feature for this project.
-  - [documentation-update.yml](https://github.com/JaKooLit/Hyprland-Dots/blob/main/.github/ISSUE_TEMPLATE/documentation-update.yml) - Use this template to propose a change to the documentation.
-  - [PULL_REQUEST_TEMPLATE.md](https://github.com/JaKooLit/Hyprland-Dots/blob/main/.github/PULL_REQUEST_TEMPLATE.md) - Use this template to submit a pull request.
-  - [COMMIT_MESSAGE_GUIDELINES.md](https://github.com/JaKooLit/Hyprland-Dots/blob/main/COMMIT_MESSAGE_GUIDELINES.md) - Read this file to learn about the commit message guidelines.
-  - [CONTRIBUTING.md](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) - Read this file to learn about the contributing guidelines.
-  - [LICENSE](https://github.com/JaKooLit/Hyprland-Dots/blob/main/LICENSE.md) - Read this file to learn about the license.
-  - [README.md](https://github.com/JaKooLit/Hyprland-Dots/blob/main/README.md) - Read this file to learn about the project.
+  - [bug.yml](https://github.com/svglan/arch-dots/blob/main/.github/ISSUE_TEMPLATE/bug.yml) - Use this template to create a report to help us improve.
+  - [feature.yml](https://github.com/svglan/arch-dots/blob/main/.github/ISSUE_TEMPLATE/feature.yml) - Use this template to suggest a feature for this project.
+  - [documentation-update.yml](https://github.com/svglan/arch-dots/blob/main/.github/ISSUE_TEMPLATE/documentation-update.yml) - Use this template to propose a change to the documentation.
+  - [PULL_REQUEST_TEMPLATE.md](https://github.com/svglan/arch-dots/blob/main/.github/PULL_REQUEST_TEMPLATE.md) - Use this template to submit a pull request.
+  - [COMMIT_MESSAGE_GUIDELINES.md](https://github.com/svglan/arch-dots/blob/main/COMMIT_MESSAGE_GUIDELINES.md) - Read this file to learn about the commit message guidelines.
+  - [CONTRIBUTING.md](https://github.com/svglan/arch-dots/blob/main/CONTRIBUTING.md) - Read this file to learn about the contributing guidelines.
+  - [LICENSE](https://github.com/svglan/arch-dots/blob/main/LICENSE.md) - Read this file to learn about the license.
+  - [README.md](https://github.com/svglan/arch-dots/blob/main/README.md) - Read this file to learn about the project.
 
 ## Contact
 
-If you have any questions, feel free to contact via [GitHub Discussions](https://github.com/JaKooLit/Hyprland-Dots/discussions) or [Through Discord Server](https://discord.gg/kool-tech-world)
+If you have any questions, feel free to contact via [GitHub Discussions](https://github.com/svglan/arch-dots/discussions) or [Through Discord Server](https://discord.gg/kool-tech-world)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.jp.md)
-[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ro.md)
-[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ru.md)
-[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ua.md)
-[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.de.md)
+[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.jp.md)
+[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ro.md)
+[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ru.md)
+[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ua.md)
+[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.de.md)
 
 <h3 align="center">
 <img align="center" width="80%" src=https://github.com/user-attachments/assets/bc18bd4d-944b-4d5f-a119-7578fa38f9b4 />
@@ -16,9 +16,9 @@
 <br>
   <a href="#-copying--installation--update-instructions-"><kbd> <br> Installation <br> </kbd></a>&ensp;&ensp;
   <a href="https://www.youtube.com/playlist?list=PLDtGd5Fw5_GjXCznR0BzCJJDIQSZJRbxx"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/discussions"><kbd> <br> Discussions <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds"><kbd> <br> Keybinds <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/discussions"><kbd> <br> Discussions <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/wiki/Keybinds"><kbd> <br> Keybinds <br> </kbd></a>&ensp;&ensp;
   <a href="https://discord.gg/kool-tech-world"><kbd> <br> Discord <br> </kbd></a>
 </div><br>
 
@@ -65,7 +65,7 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 ### 👁️‍🗨️ My Hyprland install Scripts 👁️‍🗨️
 - Automated Hyprland Scripts for Distro of choice which will pull this dotfiles if opted to install these configurations
 
-- [Arch-Linux](https://github.com/JaKooLit/Arch-Hyprland)
+- [Arch-Linux](https://github.com/svglan/arch)
 
 - [OpenSUSE(Tumbleweed)](https://github.com/JaKooLit/OpenSuse-Hyprland)
 
@@ -89,26 +89,26 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 - All screenshots are collected here [Screenshots](https://github.com/JaKooLit/screenshots/tree/main/Hyprland-ScreenShots)
 
 ### 📦 Whats new?
-- To easily track changes, I will be updating the [CHANGELOGS](https://github.com/JaKooLit/Hyprland-Dots/wiki/Changelogs)  Screenshots will be included if worth mentioning the changes!
+- To easily track changes, I will be updating the [CHANGELOGS](https://github.com/svglan/arch-dots/wiki/Changelogs)  Screenshots will be included if worth mentioning the changes!
 
 > [!NOTE]
 > Kindly note that by defeault, Kools Dots are adjusted / configured for 2k (1440p) display without scaling. 
 
 ### 💥 Copying / Installation / Update instructions 💥
-- [`MORE INFO HERE`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update) 
+- [`MORE INFO HERE`](https://github.com/svglan/arch-dots/wiki/Install_&_Update) 
 > [!Note] 
 > The auto copy script "copy.sh" will create backups of intended directories to be copied. However, still a good idea to manually backup just incase script failed to backup!
 - clone this repo by using git. Change directory, make executable and run the script
 
 > to download from Master branch
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git
+git clone --depth=1 https://github.com/svglan/arch-dots.git
 cd Hyprland-Dots
 ```
 
 > to download from Development branch (development and testing)
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git -b development
+git clone --depth=1 https://github.com/svglan/arch-dots.git -b development
 cd Hyprland-Dots
 ```
 
@@ -134,7 +134,7 @@ chmod +x upgrade.sh
 ```
 
 ## ❗❗❗ DEBIAN AND UBUNTU HEADS UP!
-- I am getting ridiculously amount of messages for updating your KooL Hyprland dotfiles. I have made a BIG note on [`WIKI`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update)
+- I am getting ridiculously amount of messages for updating your KooL Hyprland dotfiles. I have made a BIG note on [`WIKI`](https://github.com/svglan/arch-dots/wiki/Install_&_Update)
 
 
 #### ⚠️⚠️⚠️ ATTENTION - BACKUPS CREATED by SCRIPT
@@ -151,30 +151,30 @@ chmod +x upgrade.sh
 + Press SUPER W and set a wallpaper. This is also to initiate wallust for waybar, kitty (tty) and rofi themes. However, If you use the copy.sh or the release.sh, there will be a preset initial Wallpaper and you dont have to do this
 
 + Nvidia Owners. Make sure to edit your `~/.config/hypr/UserConfigs/ENVariables.conf` (highly recommended).
-- NVIDIA users / owners, after installation, check [`THIS`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)
+- NVIDIA users / owners, after installation, check [`THIS`](https://github.com/svglan/arch-dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)
 
 + If you have already set your own keybinds, monitors, etc.... Just copy over from backup created before log-out or reboot. (recommended)
 
 
 #### 📖 Known issues and possible solutions
-- check out this page [FAQ](https://github.com/JaKooLit/Hyprland-Dots/wiki/FAQ) and [UNSOLVED ISSUES](https://github.com/JaKooLit/Hyprland-Dots/wiki/Known_Issues)
+- check out this page [FAQ](https://github.com/svglan/arch-dots/wiki/FAQ) and [UNSOLVED ISSUES](https://github.com/svglan/arch-dots/wiki/Known_Issues)
 
 
 #### 🙋 QUESTIONS ?!?! ⁉️
 - FAQ! Yes you can use these dotfiles to other distro! Just ensure to install proper packages first! If it makes you feel better, I use same config on my Gentoo:)
 - QUICK HINT! Click the HINT! Waybar module (note only available in Waybar default and Simple-L [TOP] layout). Can be launched by Keybind `SUPER H`
-- More question? click here browse through this [WIKI](https://github.com/JaKooLit/Hyprland-Dots/wiki/)
-- If you want the old configs, it is collected on my "Archive" repo. See [HERE](https://github.com/JaKooLit/Hyprland-Dots-releases-Archive)
+- More question? click here browse through this [WIKI](https://github.com/svglan/arch-dots/wiki/)
+- If you want the old configs, it is collected on my "Archive" repo. See [HERE](https://github.com/svglan/arch-dots-releases-Archive)
 
 #### ⌨ Keybinds
-- Keybinds [`CLICK`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds)
+- Keybinds [`CLICK`](https://github.com/svglan/arch-dots/wiki/Keybinds)
 
 #### 🙏 Special request
 - If you have improvements on the dotfiles or configuration, feel free to submit a PR for improvement. I always welcome improvements as I am also just learning just like you guys!
 
 
 #### ✍️ Contributing
-- Want to contribute? Click [`HERE`](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) for a guide how to contribute
+- Want to contribute? Click [`HERE`](https://github.com/svglan/arch-dots/blob/main/CONTRIBUTING.md) for a guide how to contribute
 
 
 #### 🤷‍♂️ TO DO!

--- a/config/hypr/hyprlock-1080p.conf
+++ b/config/hypr/hyprlock-1080p.conf
@@ -170,7 +170,7 @@ label {
 
 # weather edit the scripts for locations
 # weather scripts are located in ~/.config/hypr/UserScripts Weather.sh and/or Weather.py
-# see https://github.com/JaKooLit/Hyprland-Dots/wiki/TIPS#%EF%B8%8F-weather-app-related-for-waybar-and-hyprlock
+# see https://github.com/svglan/arch-dots/wiki/TIPS#%EF%B8%8F-weather-app-related-for-waybar-and-hyprlock
 label {
     monitor =
     text = cmd[update:3600000] [ -f "$HOME/.cache/.weather_cache" ] && cat "$HOME/.cache/.weather_cache"

--- a/config/hypr/hyprlock.conf
+++ b/config/hypr/hyprlock.conf
@@ -171,7 +171,7 @@ label {
 
 # weather edit the scripts for locations
 # weather scripts are located in ~/.config/hypr/UserScripts Weather.sh and/or Weather.py
-# see https://github.com/JaKooLit/Hyprland-Dots/wiki/TIPS#%EF%B8%8F-weather-app-related-for-waybar-and-hyprlock
+# see https://github.com/svglan/arch-dots/wiki/TIPS#%EF%B8%8F-weather-app-related-for-waybar-and-hyprlock
 label {
     monitor =
     text = cmd[update:3600000] [ -f "$HOME/.cache/.weather_cache" ] && cat  "$HOME/.cache/.weather_cache"

--- a/config/hypr/scripts/KeyHints.sh
+++ b/config/hypr/scripts/KeyHints.sh
@@ -69,4 +69,4 @@ GDK_BACKEND=$BACKEND yad \
 " ALT E" "Rofi Emoticons" "Emoticon" \
 " H" "Launch this Quick Cheat Sheet" "" \
 "" "" "" \
-"More tips:" "https://github.com/JaKooLit/Hyprland-Dots/wiki" ""\
+"More tips:" "https://github.com/svglan/arch-dots/wiki" ""\

--- a/config/hypr/scripts/KooLsDotsUpdate.sh
+++ b/config/hypr/scripts/KooLsDotsUpdate.sh
@@ -16,7 +16,7 @@ fi
 
 # GitHub URL - KooL's dots
 branch="main"
-github_url="https://github.com/JaKooLit/Hyprland-Dots/tree/$branch/config/hypr/"
+github_url="https://github.com/svglan/arch-dots/tree/$branch/config/hypr/"
 
 # Fetch the version from GitHub URL - KooL's dots
 github_version=$(curl -s $github_url | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' | sort -V | tail -n 1 | sed 's/v//')
@@ -58,7 +58,7 @@ else
   			exit 1
 		fi
         kitty -e bash -c "
-          git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git $KooL_Dots_DIR &&
+          git clone --depth=1 https://github.com/svglan/arch-dots.git $KooL_Dots_DIR &&
           cd $KooL_Dots_DIR &&
           chmod +x copy.sh &&
           ./copy.sh &&

--- a/config/hypr/v2.3.16
+++ b/config/hypr/v2.3.16
@@ -1,5 +1,5 @@
 ### https://github.com/JaKooLit ###
-## https://github.com/JaKooLit/Hyprland-Dots
+## https://github.com/svglan/arch-dots
 ## This is to have a reference of which version would be
 
 ## note that this will always be higher than the released versions

--- a/i18n/README.de.md
+++ b/i18n/README.de.md
@@ -1,8 +1,8 @@
-[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/README.md)
-[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.jp.md)
-[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ro.md)
-[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ru.md)
-[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ua.md)
+[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/svglan/arch-dots/blob/main/README.md)
+[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.jp.md)
+[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ro.md)
+[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ru.md)
+[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ua.md)
 
 <h3 align="center">
 <img align="center" width="80%" src=https://github.com/user-attachments/assets/bc18bd4d-944b-4d5f-a119-7578fa38f9b4 />
@@ -16,9 +16,9 @@
 <br>
   <a href="#-kopieren--installation--update-anleitung-"><kbd> <br> Installation <br> </kbd></a>&ensp;&ensp;
   <a href="https://www.youtube.com/playlist?list=PLDtGd5Fw5_GjXCznR0BzCJJDIQSZJRbxx"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/discussions"><kbd> <br> Discussions <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds"><kbd> <br> Keybinds <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/discussions"><kbd> <br> Discussions <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/wiki/Keybinds"><kbd> <br> Keybinds <br> </kbd></a>&ensp;&ensp;
   <a href="https://discord.gg/kool-tech-world"><kbd> <br> Discord <br> </kbd></a>
 </div><br>
 
@@ -72,7 +72,7 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 ### 👁️‍🗨️ Meine Hyprland-Installationsskripte 👁️‍🗨️
 
 - Automatisierte Hyprland-Skripte für ein Distro deiner Wahl. Diese Skripte laden, wenn ben;tigt, meine vorkonfigurierten Dotfiles
-- [Arch-Linux](https://github.com/JaKooLit/Arch-Hyprland)
+- [Arch-Linux](https://github.com/svglan/arch)
 
 - [OpenSUSE(Tumbleweed)](https://github.com/JaKooLit/OpenSuse-Hyprland)
 
@@ -100,14 +100,14 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 
 ### 📦 Whats new?
 
-- Um Änderungen leicht nachzuvollziehen, werde ich die [CHANGELOGS](https://github.com/JaKooLit/Hyprland-Dots/wiki/Changelogs) regelmäßig aktualisieren. Es werden neue Screenshots hinzugefügt, wenn die Änderungen erwähnenswert sind!
+- Um Änderungen leicht nachzuvollziehen, werde ich die [CHANGELOGS](https://github.com/svglan/arch-dots/wiki/Changelogs) regelmäßig aktualisieren. Es werden neue Screenshots hinzugefügt, wenn die Änderungen erwähnenswert sind!
 
 > [!NOTE]
 > Bitte beachte, dass Kools Dots standardmäßig für einen 2K (1440p) Monitor ohne Skalierung angepasst und konfiguriert sind.
 
 ### 💥 Kopieren / Installation / Update-Anleitung 💥
 
-- [`Weiter Infos hier`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update)
+- [`Weiter Infos hier`](https://github.com/svglan/arch-dots/wiki/Install_&_Update)
   > [!Note]
   > Das Kopierskript "copy.sh" erstellt Backups der zu kopierenden Konfigurationsverzeichnisse. Sollte das Skript fehlschlagen, empfiehlt es sich, manuell ein Backup zu erstellen.
 - Klone das Repository mit Git, wechsle in das Verzeichnis, mache die Datei ausführbar und führe das Skript aus:
@@ -115,14 +115,14 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 > Um den Master-Branch herunterzuladen
 
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git
+git clone --depth=1 https://github.com/svglan/arch-dots.git
 cd Hyprland-Dots
 ```
 
 > Um den Entwicklungs-Branch (Development & Testing) herunterzuladen:
 
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git -b development
+git clone --depth=1 https://github.com/svglan/arch-dots.git -b development
 cd Hyprland-Dots
 ```
 
@@ -152,7 +152,7 @@ chmod +x upgrade.sh
 
 ## ❗❗❗ DEBIAN AND UBUNTU INFORMATION!
 
-- Ich bekomme eine große Menge an Nachrichten über das Updaten eurer KooL Hyprland dotfiles. Es gibt dazu eine Info im [`WIKI`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update)
+- Ich bekomme eine große Menge an Nachrichten über das Updaten eurer KooL Hyprland dotfiles. Es gibt dazu eine Info im [`WIKI`](https://github.com/svglan/arch-dots/wiki/Install_&_Update)
 
 #### ⚠️⚠️⚠️ ACHTUNG - SKRIPT-ERSTELLTE BACKUPS
 
@@ -171,24 +171,24 @@ chmod +x upgrade.sh
 
 - Für Nvidia Benutzer. Stelle sicher, dass du deine `~/.config/hypr/UserConfigs/ENVariables.conf` anpasst (unbedingt empfohlen).
 
-* Für NVIDIA Benutzer, schaue dir diese Informationen [`HIER`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Notes_to_remember#--for-nvidia-gpu-users) an.
+* Für NVIDIA Benutzer, schaue dir diese Informationen [`HIER`](https://github.com/svglan/arch-dots/wiki/Notes_to_remember#--for-nvidia-gpu-users) an.
 
 - Wenn die bereits deine Keybinds, Monitoren, usw. eingestellt hast... Kopiere die Einstellungen von dem Backup vor dem Logout / Reboot. (empfohlen)
 
 #### 📖 Bekannte Probleme und mögliche Lösungen
 
-- Schau dir diese Seite an [FAQ](https://github.com/JaKooLit/Hyprland-Dots/wiki/FAQ) und checke die [UNSOLVED ISSUES](https://github.com/JaKooLit/Hyprland-Dots/wiki/Known_Issues)
+- Schau dir diese Seite an [FAQ](https://github.com/svglan/arch-dots/wiki/FAQ) und checke die [UNSOLVED ISSUES](https://github.com/svglan/arch-dots/wiki/Known_Issues)
 
 #### 🙋 FRAGEN ?!?! ⁉️
 
 - FAQ! Die Dotfiles funktionieren auch auf anderen Distros! Stelle nur sicher, die richtigen Pakete vorher zu installieren! Falls du dich dann besser fühlst, ich benutze die selbe Konfiguration für mein Gentoo:)
 - KLEINER HINWEIS! Klicke auf das HINT! Waybar Modul (Notiz, nur in Waybar default und Simple-L [TOP] Layout verfügbar). Kann auch mit der Tastenkombination `SUPER H` gestartet werden
-- Weitere Fragen? Klicke hier um das [WIKI](https://github.com/JaKooLit/Hyprland-Dots/wiki/) zu durchstöbern.
-- Falls du eine ältere Version der Konfiguration haben möchtest, sind diese in meinem "Archive" Repository verfügbar. Siehe [HIER](https://github.com/JaKooLit/Hyprland-Dots-releases-Archive)
+- Weitere Fragen? Klicke hier um das [WIKI](https://github.com/svglan/arch-dots/wiki/) zu durchstöbern.
+- Falls du eine ältere Version der Konfiguration haben möchtest, sind diese in meinem "Archive" Repository verfügbar. Siehe [HIER](https://github.com/svglan/arch-dots-releases-Archive)
 
 #### ⌨ Keybinds
 
-- Keybinds [`KLICKE`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds)
+- Keybinds [`KLICKE`](https://github.com/svglan/arch-dots/wiki/Keybinds)
 
 #### 🙏 Hilfe gebraucht
 
@@ -196,7 +196,7 @@ chmod +x upgrade.sh
 
 #### ✍️ Contributing
 
-- Möchtest du contributen? Klicke [`HIER`](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) für eine Anleitung.
+- Möchtest du contributen? Klicke [`HIER`](https://github.com/svglan/arch-dots/blob/main/CONTRIBUTING.md) für eine Anleitung.
 
 #### 🤷‍♂️ TO DO!
 

--- a/i18n/README.jp.md
+++ b/i18n/README.jp.md
@@ -1,8 +1,8 @@
-[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/README.md)
-[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ro.md)
-[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ru.md)
-[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ua.md)
-[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.de.md)
+[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/svglan/arch-dots/blob/main/README.md)
+[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ro.md)
+[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ru.md)
+[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ua.md)
+[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.de.md)
 
 <h3 align="center">
 <img align="center" width="80%" src=https://github.com/user-attachments/assets/bc18bd4d-944b-4d5f-a119-7578fa38f9b4 />
@@ -16,9 +16,9 @@
 <br>
   <a href="#-コピー--インストール--アップデート手順-"><kbd> <br> Installation <br> </kbd></a>&ensp;&ensp;
   <a href="https://www.youtube.com/playlist?list=PLDtGd5Fw5_GjXCznR0BzCJJDIQSZJRbxx"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/discussions"><kbd> <br> Discussions <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds"><kbd> <br> Keybinds <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/discussions"><kbd> <br> Discussions <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/wiki/Keybinds"><kbd> <br> Keybinds <br> </kbd></a>&ensp;&ensp;
   <a href="https://discord.gg/kool-tech-world"><kbd> <br> Discord <br> </kbd></a>
 </div><br>
 
@@ -73,7 +73,7 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 
 - 選択したディストロ向けの自動化された Hyprland スクリプトです。これらの設定をインストールするオプションを選択した場合、対応する dotfiles を取得します。
 
-- [Arch-Linux](https://github.com/JaKooLit/Arch-Hyprland)
+- [Arch-Linux](https://github.com/svglan/arch)
 
 - [OpenSUSE(Tumbleweed)](https://github.com/JaKooLit/OpenSuse-Hyprland)
 
@@ -101,14 +101,14 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 
 ### 📦 変更点
 
-- 変更を簡単に追跡できるよう、[変更ログ](https://github.com/JaKooLit/Hyprland-Dots/wiki/Changelogs) 変更が注目に値する場合はスクリーンショットも含めます！
+- 変更を簡単に追跡できるよう、[変更ログ](https://github.com/svglan/arch-dots/wiki/Changelogs) 変更が注目に値する場合はスクリーンショットも含めます！
 
 > [注意!]
 > デフォルトでは、Kools Dots はスケーリングなしの 2K (1440p) ディスプレイ向けに調整・設定されています。
 
 ### 💥 コピー / インストール / アップデート手順 💥
 
-- [`ここに詳細を記載しています`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update)
+- [`ここに詳細を記載しています`](https://github.com/svglan/arch-dots/wiki/Install_&_Update)
   > [注意!]
   > 自動コピーのスクリプトである "copy.sh" は、コピー対象のディレクトリをバックアップします。しかし、スクリプトがバックアップに失敗する可能性もあるため、手動でバックアップを取るのも良い考えです！
 - このリポジトリを git でクローンし、ディレクトリを移動して、実行可能にした後、スクリプトを実行してください。
@@ -116,14 +116,14 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 > Master ブランチからダウンロードする場合
 
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git
+git clone --depth=1 https://github.com/svglan/arch-dots.git
 cd Hyprland-Dots
 ```
 
 > 開発ブランチ（Development）からダウンロードする場合（開発およびテスト用）
 
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git -b development
+git clone --depth=1 https://github.com/svglan/arch-dots.git -b development
 cd Hyprland-Dots
 ```
 
@@ -153,7 +153,7 @@ chmod +x upgrade.sh
 
 ## ❗❗❗ DEBIAN および UBUNTU ユーザーへの注意！
 
-- KooL Hyprland の dotfiles 更新に関するメッセージが大量に届いています。 [`WIKI`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update)に大きく注意書きを記載しました。
+- KooL Hyprland の dotfiles 更新に関するメッセージが大量に届いています。 [`WIKI`](https://github.com/svglan/arch-dots/wiki/Install_&_Update)に大きく注意書きを記載しました。
 
 #### ⚠️⚠️⚠️ スクリプトによって作成されたバックアップについての注意
 
@@ -172,24 +172,24 @@ chmod +x upgrade.sh
 
 - NVIDIA の所有者へ。`~/.config/hypr/UserConfigs/ENVariables.conf`を編集してください（強く推奨）。
 
-* NVIDIA の所有者とユーザーへ。 インsトール後に [`THIS`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)を確認してください。
+* NVIDIA の所有者とユーザーへ。 インsトール後に [`THIS`](https://github.com/svglan/arch-dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)を確認してください。
 
 - 既に独自のキー設定やモニター設定を行っている場合は、ログアウトや再起動前に作成されたバックアップからコピーしてください。（推奨）
 
 #### 📖 既知の問題と可能な解決策
 
-- こちらのページを確認してください: [FAQ](https://github.com/JaKooLit/Hyprland-Dots/wiki/FAQ) & [UNSOLVED ISSUES](https://github.com/JaKooLit/Hyprland-Dots/wiki/Known_Issues)
+- こちらのページを確認してください: [FAQ](https://github.com/svglan/arch-dots/wiki/FAQ) & [UNSOLVED ISSUES](https://github.com/svglan/arch-dots/wiki/Known_Issues)
 
 #### 🙋 質問対応 ⁉️
 
 - FAQ! はい、これらの dotfiles は他のディストロでも使用できます！ただし、適切なパッケージを事前にインストールしてください！安心できるなら、私も Gentoo で同じ設定を使っています :)
 - クイックヒント！ Waybar モジュールの HINT! をクリックしてください。 (Waybar のデフォルトレイアウトおよび Simple-L [TOP] レイアウトでのみ利用可能)。キーバインドの `SUPER H`でも起動できます。
-- さらに質問がありますか？ こちらをクリックして [WIKI](https://github.com/JaKooLit/Hyprland-Dots/wiki/)を参照してください。
-- 旧設定が欲しい場合, すべて "Archive" リポジトリにまとめています。詳しくは[HERE](https://github.com/JaKooLit/Hyprland-Dots-releases-Archive)をご覧ください。
+- さらに質問がありますか？ こちらをクリックして [WIKI](https://github.com/svglan/arch-dots/wiki/)を参照してください。
+- 旧設定が欲しい場合, すべて "Archive" リポジトリにまとめています。詳しくは[HERE](https://github.com/svglan/arch-dots-releases-Archive)をご覧ください。
 
 #### ⌨ キーバインド
 
-- キーバインドの説明はこちら： [`CLICK`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds)
+- キーバインドの説明はこちら： [`CLICK`](https://github.com/svglan/arch-dots/wiki/Keybinds)
 
 #### 🙏 スペシャルリクエスト
 

--- a/i18n/README.ro.md
+++ b/i18n/README.ro.md
@@ -1,8 +1,8 @@
-[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/README.md)
-[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.jp.md)
-[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ru.md)
-[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ua.md)
-[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.de.md)
+[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/svglan/arch-dots/blob/main/README.md)
+[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.jp.md)
+[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ru.md)
+[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ua.md)
+[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.de.md)
 
 <h3 align="center">
 <img align="center" width="80%" src=https://github.com/user-attachments/assets/bc18bd4d-944b-4d5f-a119-7578fa38f9b4 />
@@ -17,9 +17,9 @@
 <br>
   <a href="#-instrucțiuni-de-copiere--instalare--actualizare-"><kbd> <br> Instalare <br> </kbd></a>&ensp;&ensp;
   <a href="https://www.youtube.com/playlist?list=PLDtGd5Fw5_GjXCznR0BzCJJDIQSZJRbxx"><kbd> <br> Youtube <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/discussions"><kbd> <br> Discuții <br> </kbd></a>&ensp;&ensp;
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds"><kbd> <br> Comenzi rapide <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/wiki"><kbd> <br> Wiki <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/discussions"><kbd> <br> Discuții <br> </kbd></a>&ensp;&ensp;
+  <a href="https://github.com/svglan/arch-dots/wiki/Keybinds"><kbd> <br> Comenzi rapide <br> </kbd></a>&ensp;&ensp;
   <a href="https://discord.gg/kool-tech-world"><kbd> <br> Discord <br> </kbd></a>
 </div><br>
 
@@ -68,7 +68,7 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 ### 👁️‍🗨️ Scripturile mele de instalare Hyprland 👁️‍🗨️
 - Scripturi automate Hyprland pentru distribuția aleasă, care vor descărca aceste dotfiles dacă optezi pentru instalarea acestor configurații
 
-- [Arch-Linux](https://github.com/JaKooLit/Arch-Hyprland)
+- [Arch-Linux](https://github.com/svglan/arch)
 - [OpenSUSE(Tumbleweed)](https://github.com/JaKooLit/OpenSuse-Hyprland)
 - [Fedora-Linux](https://github.com/JaKooLit/Fedora-Hyprland)
 - [Debian-Linux (Trixie & SID)](https://github.com/JaKooLit/Debian-Hyprland)
@@ -88,13 +88,13 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 - Toate capturile de ecran sunt colectate aici [Capturi de ecran](https://github.com/JaKooLit/screenshots/tree/main/Hyprland-ScreenShots)
 
 ### 📦 Ce mai e nou?
-- Pentru a urmări ușor modificările, voi actualiza [Jurnalul de modificări](https://github.com/JaKooLit/Hyprland-Dots/wiki/Changelogs). Capturile de ecran vor fi incluse dacă modificările merită menționate!
+- Pentru a urmări ușor modificările, voi actualiza [Jurnalul de modificări](https://github.com/svglan/arch-dots/wiki/Changelogs). Capturile de ecran vor fi incluse dacă modificările merită menționate!
 
 > [!NOTĂ]
 > Reține că, în mod implicit, dotfiles-urile lui Kool sunt ajustate/configurate pentru afișaje 2k (1440p) fără scalare.
 
 ### 💥 Instrucțiuni de copiere / instalare / actualizare 💥
-- [`MAI MULTE INFORMAȚII AICI`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update) 
+- [`MAI MULTE INFORMAȚII AICI`](https://github.com/svglan/arch-dots/wiki/Install_&_Update) 
 > [!Notă] 
 > Scriptul automat de copiere „copy.sh” va crea copii de rezervă ale directoarelor care urmează să fie copiate. Totuși, este o idee bună să faci manual o copie de rezervă, în caz că scriptul nu reușește să o facă!
 
@@ -102,13 +102,13 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 
 > pentru a descărca din ramura Master
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git
+git clone --depth=1 https://github.com/svglan/arch-dots.git
 cd Hyprland-Dots
 ```
 
 > pentru a descărca din ramura Development (dezvoltare și testare)
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git -b development
+git clone --depth=1 https://github.com/svglan/arch-dots.git -b development
 cd Hyprland-Dots
 ```
 
@@ -134,7 +134,7 @@ chmod +x upgrade.sh
 ```
 
 ## ❗❗❗ ATENȚIE PENTRU UTILIZATORII DEBIAN ȘI UBUNTU!
-- Primesc o mulțime de mesaje despre actualizarea dotfiles-urilor Hyprland ale lui KooL. Am făcut o notă mare în [`WIKI`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update)
+- Primesc o mulțime de mesaje despre actualizarea dotfiles-urilor Hyprland ale lui KooL. Am făcut o notă mare în [`WIKI`](https://github.com/svglan/arch-dots/wiki/Install_&_Update)
 
 #### ⚠️⚠️⚠️ ATENȚIE - COPII DE REZERVĂ CREATE DE SCRIPT
 > [!ATENȚIE]
@@ -149,27 +149,27 @@ chmod +x upgrade.sh
 + Apasă SUPER W și setează o imagine de fundal. Aceasta este și pentru a inițializa wallust pentru temele waybar, kitty (tty) și rofi. Totuși, dacă folosești copy.sh sau release.sh, va exista o imagine de fundal inițială presetată și nu va trebui să faci asta
 
 + Proprietari de Nvidia. Asigură-te că editezi `~/.config/hypr/UserConfigs/ENVariables.conf` (foarte recomandat).
-- Utilizatori / proprietari de Nvidia, după instalare, verifică [`ACESTA`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)
+- Utilizatori / proprietari de Nvidia, după instalare, verifică [`ACESTA`](https://github.com/svglan/arch-dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)
 
 + Dacă ți-ai setat deja propriile comenzi rapide, monitoare etc., doar copiază-le din copia de rezervă creată înainte de a te deconecta sau reporni. (recomandat)
 
 #### 📖 Probleme cunoscute și posibile soluții
-- verifică această pagină [Întrebări frecvente](https://github.com/JaKooLit/Hyprland-Dots/wiki/FAQ) și [PROBLEME NESOLUȚIONATE](https://github.com/JaKooLit/Hyprland-Dots/wiki/Known_Issues)
+- verifică această pagină [Întrebări frecvente](https://github.com/svglan/arch-dots/wiki/FAQ) și [PROBLEME NESOLUȚIONATE](https://github.com/svglan/arch-dots/wiki/Known_Issues)
 
 #### 🙋 ÎNTREBĂRI ?!?! ⁉️
 - Întrebări frecvente! Da, poți folosi aceste dotfiles pe alte distribuții! Asigură-te doar că instalezi pachetele corespunzătoare mai întâi! Dacă te face să te simți mai bine, folosesc aceeași configurație pe Gentoo-ul meu :)
 - SFAT RAPID! Apasă pe modulul HINT! din Waybar (notă: disponibil doar în layout-urile Waybar implicit și Simple-L [SUS]). Poate fi lansat cu comanda rapidă `SUPER H`
-- Mai multe întrebări? click aici pentru a răsfoi acest [WIKI](https://github.com/JaKooLit/Hyprland-Dots/wiki/)
-- Dacă vrei vechile configurații, acestea sunt colectate în repo-ul meu „Archive”. Vezi [AICI](https://github.com/JaKooLit/Hyprland-Dots-releases-Archive)
+- Mai multe întrebări? click aici pentru a răsfoi acest [WIKI](https://github.com/svglan/arch-dots/wiki/)
+- Dacă vrei vechile configurații, acestea sunt colectate în repo-ul meu „Archive”. Vezi [AICI](https://github.com/svglan/arch-dots-releases-Archive)
 
 #### ⌨ Comenzi rapide
-- Comenzi rapide [`CLICK`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds)
+- Comenzi rapide [`CLICK`](https://github.com/svglan/arch-dots/wiki/Keybinds)
 
 #### 🙏 Cerere specială
 - Dacă ai îmbunătățiri pentru dotfiles sau configurații, nu ezita să trimiți un PR pentru îmbunătățiri. Întotdeauna primesc cu bucurie îmbunătățiri, deoarece și eu învăț, la fel ca voi!
 
 #### ✍️ Contribuții
-- Vrei să contribui? Click [`AICI`](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) pentru un ghid despre cum să contribui
+- Vrei să contribui? Click [`AICI`](https://github.com/svglan/arch-dots/blob/main/CONTRIBUTING.md) pentru un ghid despre cum să contribui
 
 #### 🤷‍♂️ DE FĂCUT!
 - [ ] Ajustarea dotfiles-urilor - 🚧 în progres constant 

--- a/i18n/README.ru.md
+++ b/i18n/README.ru.md
@@ -1,8 +1,8 @@
-[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/README.md)
-[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.jp.md)
-[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ro.md)
-[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ua.md)
-[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.de.md)
+[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/svglan/arch-dots/blob/main/README.md)
+[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.jp.md)
+[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ro.md)
+[![ua](https://img.shields.io/badge/lang-ua-white.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ua.md)
+[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.de.md)
 
 <h3 align="center">
 <img align="center" width="80%" src=https://github.com/user-attachments/assets/bc18bd4d-944b-4d5f-a119-7578fa38f9b4 />
@@ -16,9 +16,9 @@
 <br>
   <a href="#-инструкции-по-копированию--установке--обновлению-"><kbd> <br> Установка <br> </kbd></a>  
   <a href="https://www.youtube.com/playlist?list=PLDtGd5Fw5_GjXCznR0BzCJJDIQSZJRbxx"><kbd> <br> YouTube <br> </kbd></a>  
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki"><kbd> <br> Вики <br> </kbd></a>  
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/discussions"><kbd> <br> Обсуждения <br> </kbd></a>  
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds"><kbd> <br> Горячие клавиши <br> </kbd></a>  
+  <a href="https://github.com/svglan/arch-dots/wiki"><kbd> <br> Вики <br> </kbd></a>  
+  <a href="https://github.com/svglan/arch-dots/discussions"><kbd> <br> Обсуждения <br> </kbd></a>  
+  <a href="https://github.com/svglan/arch-dots/wiki/Keybinds"><kbd> <br> Горячие клавиши <br> </kbd></a>  
   <a href="https://discord.gg/kool-tech-world"><kbd> <br> Discord <br> </kbd></a>
 </div><br>
 
@@ -67,7 +67,7 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 ### 👁️‍🗨️ Мои скрипты установки Hyprland 👁️‍🗨️
 - Автоматические скрипты Hyprland для выбранного дистрибутива, которые загрузят эти dotfiles, если вы выберете установку этих конфигураций
 
-- [Arch-Linux](https://github.com/JaKooLit/Arch-Hyprland)
+- [Arch-Linux](https://github.com/svglan/arch)
 - [OpenSUSE(Tumbleweed)](https://github.com/JaKooLit/OpenSuse-Hyprland)
 - [Fedora-Linux](https://github.com/JaKooLit/Fedora-Hyprland)
 - [Debian-Linux (Trixie & SID)](https://github.com/JaKooLit/Debian-Hyprland)
@@ -87,13 +87,13 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 - Все скриншоты собраны здесь [Скриншоты](https://github.com/JaKooLit/screenshots/tree/main/Hyprland-ScreenShots)
 
 ### 📦 Что нового?
-- Чтобы легко отслеживать изменения, я буду обновлять [Журнал изменений](https://github.com/JaKooLit/Hyprland-Dots/wiki/Changelogs). Скриншоты будут включены, если изменения заслуживают упоминания!
+- Чтобы легко отслеживать изменения, я буду обновлять [Журнал изменений](https://github.com/svglan/arch-dots/wiki/Changelogs). Скриншоты будут включены, если изменения заслуживают упоминания!
 
 > [!ПРИМЕЧАНИЕ]
 > Обратите внимание, что по умолчанию dotfiles от KooL настроены для дисплеев 2k (1440p) без масштабирования.
 
 ### 💥 Инструкции по копированию / установке / обновлению 💥
-- [`БОЛЬШЕ ИНФОРМАЦИИ ЗДЕСЬ`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update) 
+- [`БОЛЬШЕ ИНФОРМАЦИИ ЗДЕСЬ`](https://github.com/svglan/arch-dots/wiki/Install_&_Update) 
 > [!Примечание] 
 > Автоматический скрипт копирования „copy.sh“ создаёт резервные копии директорий, которые будут скопированы. Тем не менее, рекомендуется сделать резервную копию вручную на случай, если скрипт не сможет этого сделать!
 
@@ -101,13 +101,13 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 
 > для загрузки из ветки Master
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git
+git clone --depth=1 https://github.com/svglan/arch-dots.git
 cd Hyprland-Dots
 ```
 
 > для загрузки из ветки Development (разработка и тестирование)
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git -b development
+git clone --depth=1 https://github.com/svglan/arch-dots.git -b development
 cd Hyprland-Dots
 ```
 
@@ -133,7 +133,7 @@ chmod +x upgrade.sh
 ```
 
 ## ❗❗❗ ВНИМАНИЕ ДЛЯ ПОЛЬЗОВАТЕЛЕЙ DEBIAN И UBUNTU!
-- Я получаю огромное количество сообщений об обновлении dotfiles Hyprland от KooL. Я сделал большую заметку в [`ВИКИ`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update)
+- Я получаю огромное количество сообщений об обновлении dotfiles Hyprland от KooL. Я сделал большую заметку в [`ВИКИ`](https://github.com/svglan/arch-dots/wiki/Install_&_Update)
 
 #### ⚠️⚠️⚠️ ВНИМАНИЕ - РЕЗЕРВНЫЕ КОПИИ, СОЗДАННЫЕ СКРИПТОМ
 > [!ВНИМАНИЕ]
@@ -148,27 +148,27 @@ chmod +x upgrade.sh
 + Нажмите SUPER W и установите обои. Это также необходимо для инициализации wallust для тем waybar, kitty (tty) и rofi. Однако, если вы используете copy.sh или release.sh, начальные обои уже будут установлены, и этого делать не придётся
 
 + Владельцы Nvidia. Обязательно отредактируйте `~/.config/hypr/UserConfigs/ENVariables.conf` (настоятельно рекомендуется).
-- Пользователи / владельцы Nvidia, после установки проверьте [`ЭТО`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)
+- Пользователи / владельцы Nvidia, после установки проверьте [`ЭТО`](https://github.com/svglan/arch-dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)
 
 + Если вы уже настроили свои горячие клавиши, мониторы и т.д., просто скопируйте их из созданной резервной копии перед выходом из системы или перезагрузкой. (рекомендуется)
 
 #### 📖 Известные проблемы и возможные решения
-- ознакомьтесь с этой страницей [Часто задаваемые вопросы](https://github.com/JaKooLit/Hyprland-Dots/wiki/FAQ) и [НЕРЕШЁННЫЕ ПРОБЛЕМЫ](https://github.com/JaKooLit/Hyprland-Dots/wiki/Known_Issues)
+- ознакомьтесь с этой страницей [Часто задаваемые вопросы](https://github.com/svglan/arch-dots/wiki/FAQ) и [НЕРЕШЁННЫЕ ПРОБЛЕМЫ](https://github.com/svglan/arch-dots/wiki/Known_Issues)
 
 #### 🙋 ВОПРОСЫ ?!?! ⁉️
 - Часто задаваемые вопросы! Да, вы можете использовать эти dotfiles на других дистрибутивах! Просто убедитесь, что сначала установлены соответствующие пакеты! Если вам от этого легче, я использую ту же конфигурацию на моём Gentoo :)
 - БЫСТРЫЙ СОВЕТ! Нажмите на модуль HINT! в Waybar (примечание: доступно только в стандартном и Simple-L [ВЕРХНЕМ] макете Waybar). Можно запустить с помощью горячей клавиши `SUPER H`
-- Ещё вопросы? щёлкните здесь, чтобы просмотреть эту [ВИКИ](https://github.com/JaKooLit/Hyprland-Dots/wiki/)
-- Если вам нужны старые конфигурации, они собраны в моём репозитории „Archive“. Смотрите [ЗДЕСЬ](https://github.com/JaKooLit/Hyprland-Dots-releases-Archive)
+- Ещё вопросы? щёлкните здесь, чтобы просмотреть эту [ВИКИ](https://github.com/svglan/arch-dots/wiki/)
+- Если вам нужны старые конфигурации, они собраны в моём репозитории „Archive“. Смотрите [ЗДЕСЬ](https://github.com/svglan/arch-dots-releases-Archive)
 
 #### ⌨ Горячие клавиши
-- Горячие клавиши [`ЩЁЛКНИТЕ`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds)
+- Горячие клавиши [`ЩЁЛКНИТЕ`](https://github.com/svglan/arch-dots/wiki/Keybinds)
 
 #### 🙏 Особая просьба
 - Если у вас есть улучшения для dotfiles или конфигураций, не стесняйтесь отправить PR для улучшений. Я всегда приветствую улучшения, так как тоже учусь, как и вы!
 
 #### ✍️ Вклад
-- Хотите внести вклад? Щёлкните [`ЗДЕСЬ`](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) для руководства по внесению вклада
+- Хотите внести вклад? Щёлкните [`ЗДЕСЬ`](https://github.com/svglan/arch-dots/blob/main/CONTRIBUTING.md) для руководства по внесению вклада
 
 #### 🤷‍♂️ ЧТО ДЕЛАТЬ!
 - [ ] Настройка dotfiles - 🚧 в постоянном прогрессе 

--- a/i18n/README.ua.md
+++ b/i18n/README.ua.md
@@ -1,8 +1,8 @@
-[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/README.md)
-[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.jp.md)
-[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ro.md)
-[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.ru.md)
-[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/JaKooLit/Hyprland-Dots/blob/main/i18n/README.de.md)
+[![en](https://img.shields.io/badge/lang-en-yellow.svg)](https://github.com/svglan/arch-dots/blob/main/README.md)
+[![jp](https://img.shields.io/badge/lang-jp-blue.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.jp.md)
+[![ro](https://img.shields.io/badge/lang-ro-green.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ro.md)
+[![ru](https://img.shields.io/badge/lang-ru-red.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.ru.md)
+[![de](https://img.shields.io/badge/lang-de-magenta.svg)](https://github.com/svglan/arch-dots/blob/main/i18n/README.de.md)
 
 <h3 align="center">
 <img align="center" width="80%" src=https://github.com/user-attachments/assets/bc18bd4d-944b-4d5f-a119-7578fa38f9b4 />
@@ -16,9 +16,9 @@
 <br>
   <a href="#-інструкції-з-копіювання--встановлення--оновлення-"><kbd> <br> Встановлення <br> </kbd></a>  
   <a href="https://www.youtube.com/playlist?list=PLDtGd5Fw5_GjXCznR0BzCJJDIQSZJRbxx"><kbd> <br> YouTube <br> </kbd></a>  
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki"><kbd> <br> Вікі <br> </kbd></a>  
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/discussions"><kbd> <br> Обговорення <br> </kbd></a>  
-  <a href="https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds"><kbd> <br> Гарячі клавіші <br> </kbd></a>   
+  <a href="https://github.com/svglan/arch-dots/wiki"><kbd> <br> Вікі <br> </kbd></a>  
+  <a href="https://github.com/svglan/arch-dots/discussions"><kbd> <br> Обговорення <br> </kbd></a>  
+  <a href="https://github.com/svglan/arch-dots/wiki/Keybinds"><kbd> <br> Гарячі клавіші <br> </kbd></a>   
   <a href="https://discord.gg/kool-tech-world"><kbd> <br> Discord <br> </kbd></a>
 </div><br>
 
@@ -67,7 +67,7 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 ### 👁️‍🗨️ Мої скрипти встановлення Hyprland 👁️‍🗨️
 - Автоматичні скрипти Hyprland для обраного дистрибутива, які завантажать ці dotfiles, якщо ви оберете встановлення цих конфігурацій
 
-- [Arch-Linux](https://github.com/JaKooLit/Arch-Hyprland)
+- [Arch-Linux](https://github.com/svglan/arch)
 - [OpenSUSE(Tumbleweed)](https://github.com/JaKooLit/OpenSuse-Hyprland)
 - [Fedora-Linux](https://github.com/JaKooLit/Fedora-Hyprland)
 - [Debian-Linux (Trixie & SID)](https://github.com/JaKooLit/Debian-Hyprland)
@@ -87,13 +87,13 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 - Усі скріншоти зібрано тут [Скріншоти](https://github.com/JaKooLit/screenshots/tree/main/Hyprland-ScreenShots)
 
 ### 📦 Що нового?
-- Щоб легко відстежувати зміни, я оновлюватиму [Журнал змін](https://github.com/JaKooLit/Hyprland-Dots/wiki/Changelogs). Скріншоти будуть додані, якщо зміни варті згадки!
+- Щоб легко відстежувати зміни, я оновлюватиму [Журнал змін](https://github.com/svglan/arch-dots/wiki/Changelogs). Скріншоти будуть додані, якщо зміни варті згадки!
 
 > [!ПРИМІТКА]
 > Зверніть увагу, що за замовчуванням dotfiles від KooL налаштовані для дисплеїв 2k (1440p) без масштабування.
 
 ### 💥 Інструкції з копіювання / встановлення / оновлення 💥
-- [`БІЛЬШЕ ІНФОРМАЦІЇ ТУТ`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update) 
+- [`БІЛЬШЕ ІНФОРМАЦІЇ ТУТ`](https://github.com/svglan/arch-dots/wiki/Install_&_Update) 
 > [!Примітака] 
 > Автоматичний скрипт копіювання „copy.sh“ створює резервні копії директорій, які будуть скопійовані. Проте рекомендується зробити резервну копію вручну на випадок, якщо скрипт не зможе цього зробити!
 
@@ -101,13 +101,13 @@ sh <(curl -L https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/Distr
 
 > для завантаження з гілки Master
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git
+git clone --depth=1 https://github.com/svglan/arch-dots.git
 cd Hyprland-Dots
 ```
 
 > для завантаження з гілки Development (розробка та тестування)
 ```bash
-git clone --depth=1 https://github.com/JaKooLit/Hyprland-Dots.git -b development
+git clone --depth=1 https://github.com/svglan/arch-dots.git -b development
 cd Hyprland-Dots
 ```
 
@@ -133,7 +133,7 @@ chmod +x upgrade.sh
 ```
 
 ## ❗❗❗ УВАГА ДЛЯ КОРИСТУВАЧІВ DEBIAN ТА UBUNTU!
-- Я отримую величезну кількість повідомлень щодо оновлення dotfiles Hyprland від KooL. Я зробив велику примітку у [`ВІКІ`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Install_&_Update)
+- Я отримую величезну кількість повідомлень щодо оновлення dotfiles Hyprland від KooL. Я зробив велику примітку у [`ВІКІ`](https://github.com/svglan/arch-dots/wiki/Install_&_Update)
 
 #### ⚠️⚠️⚠️ УВАГА - РЕЗЕРВНІ КОПІЇ, СТВОРЕНІ СКРИПТОМ
 > [!УВАГА]
@@ -148,27 +148,27 @@ chmod +x upgrade.sh
 + Натисніть SUPER W і встановіть шпалери. Це також необхідно для ініціалізації wallust для тем waybar, kitty (tty) і rofi. Однак, якщо ви використовуєте copy.sh або release.sh, початкові шпалери вже будуть встановлені, і цього робити не доведеться
 
 + Власники Nvidia. Обов’язково відредагуйте `~/.config/hypr/UserConfigs/ENVariables.conf` (настійно рекомендується).
-- Користувачі / власники Nvidia, після встановлення перевірте [`ЦЕ`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)
+- Користувачі / власники Nvidia, після встановлення перевірте [`ЦЕ`](https://github.com/svglan/arch-dots/wiki/Notes_to_remember#--for-nvidia-gpu-users)
 
 + Якщо ви вже налаштували власні гарячі клавіші, монітори тощо, просто скопіюйте їх із створеної резервної копії перед виходом із системи або перезавантаженням. (рекомендується)
 
 #### 📖 Відомі проблеми та можливі рішення
-- перегляньте цю сторінку [Поширені запитання](https://github.com/JaKooLit/Hyprland-Dots/wiki/FAQ) та [НЕРОЗВ’ЯЗАНІ ПРОБЛЕМИ](https://github.com/JaKooLit/Hyprland-Dots/wiki/Known_Issues)
+- перегляньте цю сторінку [Поширені запитання](https://github.com/svglan/arch-dots/wiki/FAQ) та [НЕРОЗВ’ЯЗАНІ ПРОБЛЕМИ](https://github.com/svglan/arch-dots/wiki/Known_Issues)
 
 #### 🙋 ЗАПИТАННЯ ?!?! ⁉️
 - Поширені запитання! Так, ви можете використовувати ці dotfiles на інших дистрибутивах! Просто переконайтеся, що спочатку встановлено відповідні пакети! Якщо вам від цього легше, я використовую ту саму конфігурацію на моєму Gentoo :)
 - ШВИДКА ПОРАДА! Натисніть на модуль HINT! у Waybar (примітка: доступно лише у стандартному та Simple-L [ВЕРХНЬОМУ] макеті Waybar). Можна запустити за допомогою гарячої клавіші `SUPER H`
-- Ще запитання? натисніть тут, щоб переглянути цю [ВІКІ](https://github.com/JaKooLit/Hyprland-Dots/wiki/)
-- Якщо вам потрібні старі конфігурації, вони зібрані в моєму репозиторії „Archive“. Дивіться [ТУТ](https://github.com/JaKooLit/Hyprland-Dots-releases-Archive)
+- Ще запитання? натисніть тут, щоб переглянути цю [ВІКІ](https://github.com/svglan/arch-dots/wiki/)
+- Якщо вам потрібні старі конфігурації, вони зібрані в моєму репозиторії „Archive“. Дивіться [ТУТ](https://github.com/svglan/arch-dots-releases-Archive)
 
 #### ⌨ Гарячі клавіші
-- Гарячі клавіші [`КЛІКНІТЬ`](https://github.com/JaKooLit/Hyprland-Dots/wiki/Keybinds)
+- Гарячі клавіші [`КЛІКНІТЬ`](https://github.com/svglan/arch-dots/wiki/Keybinds)
 
 #### 🙏 Особливе прохання
 - Якщо у вас є покращення для dotfiles або конфігурацій, не соромтеся надіслати PR для покращень. Я завжди вітаю покращення, адже я також вчуся, як і ви!
 
 #### ✍️ Внесок
-- Хочете зробити внесок? Клікніть [`ТУТ`](https://github.com/JaKooLit/Hyprland-Dots/blob/main/CONTRIBUTING.md) для посібника зі внесення внеску
+- Хочете зробити внесок? Клікніть [`ТУТ`](https://github.com/svglan/arch-dots/blob/main/CONTRIBUTING.md) для посібника зі внесення внеску
 
 #### 🤷‍♂️ ЩО РОБИТИ!
 - [ ] Налаштування dotfiles - 🚧 у постійному прогресі 


### PR DESCRIPTION
## Summary
- replace JaKooLit links with svglan equivalents

## Testing
- `shellcheck config/hypr/scripts/KeyHints.sh config/hypr/scripts/KooLsDotsUpdate.sh` *(fails: SC1009, SC1073, SC1072, etc.)*
- `bash -n config/hypr/scripts/KeyHints.sh config/hypr/scripts/KooLsDotsUpdate.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c030422e8c8332b69bcb274c1cc834